### PR TITLE
Join-btn text size increase on mid-screen, fixed article h2 size bug

### DIFF
--- a/components/ArticleComponent.vue
+++ b/components/ArticleComponent.vue
@@ -171,31 +171,35 @@ export default {
   display: flex;
 }
 @media only screen and (max-width: $mid-screen) {
-  .main-article-text ul li,
-  .main-article-text ul li span,
-  .main-article-text ol li,
-  .main-article-text ol li span,
   .main-article-text-section p,
   .main-article-text-section p em,
   .main-article-text-section p strong,
+  .main-article-text-section p a,
   .main-article-text-section li em,
   .main-article-text-section li strong,
-  .main-article-text-section span {
+  .main-article-text-section li a,
+  .main-article-text-section span,
+  .main-article-text ul li,
+  .main-article-text ul li span,
+  .main-article-text ol li,
+  .main-article-text ol li span {
     font-size: 1.9rem;
     line-height: 3.25rem;
   }
 }
 @media only screen and (max-width: $x-small-screen) {
-  .main-article-text ul li,
-  .main-article-text ul li span,
-  .main-article-text ol li,
-  .main-article-text ol li span,
   .main-article-text-section p,
   .main-article-text-section p em,
   .main-article-text-section p strong,
+  .main-article-text-section p a,
   .main-article-text-section li em,
   .main-article-text-section li strong,
-  .main-article-text-section span {
+  .main-article-text-section li a,
+  .main-article-text-section span,
+  .main-article-text ul li,
+  .main-article-text ul li span,
+  .main-article-text ol li,
+  .main-article-text ol li span {
     font-size: 2.25rem;
     line-height: 3.5rem;
   }

--- a/components/ArticleComponent.vue
+++ b/components/ArticleComponent.vue
@@ -128,7 +128,7 @@ export default {
 .main-article-text h1 strong {
   font-size: 3.5rem;
 }
-.main-article-text h2
+.main-article-text h2,
 .main-article-text h2 strong {
   font-size: 3rem;
 }

--- a/components/GetNotifiedSection.vue
+++ b/components/GetNotifiedSection.vue
@@ -140,7 +140,7 @@ export default {
         .footer-email-input,
         .footer-join-btn,
         .footer-form-label {
-          font-size: 1.8rem;
+          font-size: 2rem;
         }
       }
     @media only screen and (max-width: $small-screen) {

--- a/components/MobileNav.vue
+++ b/components/MobileNav.vue
@@ -277,7 +277,7 @@ export default {
   position: absolute;
   height: 0.35rem;
   width: 100%;
-  background: var(--on-background);
+  background-color: var(--on-background);
   border-radius: 1rem;
   opacity: 1;
   left: 0;


### PR DESCRIPTION
1. Made join btn text size slightly large on mid-screen 
2. Corrected a syntax error that caused the h2's in the article page to not have the correct font-size
3. Corrected syntax in mobile nav (for best practices, not to fix anything)
4. Included article links in media query font size changes so that the font size of the links would be the same as the rest of the page on mid-screen and below

