### PR TITLE
Article font changes

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -135,7 +135,7 @@
   --see-more-color: var(--hover);
 }
 
-@import url("https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;500;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&display=swap");
 
 *,

--- a/components/ArticleComponent.vue
+++ b/components/ArticleComponent.vue
@@ -186,6 +186,30 @@ export default {
     font-size: 1.9rem;
     line-height: 3.25rem;
   }
+  .main-article-text h1,
+  .main-article-text h1 strong {
+    font-size: 3rem;
+  }
+  .main-article-text h2,
+  .main-article-text h2 strong {
+    font-size: 2.75rem;
+  }
+  .main-article-text h3,
+  .main-article-text h3 strong {
+    font-size: 2.5rem;
+  }
+  .main-article-text h4,
+  .main-article-text h4 strong {
+    font-size: 2.25rem;
+  }
+  .main-article-text h5,
+  .main-article-text h5 strong {
+    font-size: 2rem;
+  }
+  .main-article-text h6,
+  .main-article-text h6 strong{
+    font-size: 1.75rem;
+  }
 }
 @media only screen and (max-width: $x-small-screen) {
   .main-article-text-section p,

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -73,6 +73,7 @@ export default {
 }
 #sidebar-article-details-title {
   font-size: 1.55rem;
+  font-weight: 500;
   line-height: 1.35;
   text-decoration: none;
   color: var(--on-background);


### PR DESCRIPTION
1. Made article headings smaller on mid-screen and below so that they are not too similar to the size of the logo
2. Removed font-weight 500 from the import statement of the Merriweather font because there Merriweather does not have that font-weight
3. Made the sidebar article title have a font-weight of 500