### PR TITLE
2 small changes

### DIFF
--- a/components/CategoriesTextBelow.vue
+++ b/components/CategoriesTextBelow.vue
@@ -45,8 +45,7 @@ export default {
   margin-top: 1rem;
 }
 .article-image {
-  background-repeat: no-repeat;
-  background-size: cover;
+  object-fit: cover;
   border-radius: 1.5rem;
 }
 .category-cat {

--- a/components/MobileNav.vue
+++ b/components/MobileNav.vue
@@ -233,7 +233,7 @@ export default {
 .mobile-nav {
   width: 100%;
   //makes up for the height and padding of the logo-menu-box (6.5rem + .8rem +.45rem)
-  height: calc(100vh - 7.75rem);
+  height: calc(100vh - 8.1rem);
   background-color: var(--mobile-nav-background);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
1. Adjusted height of the mobile nav to match the updated padding for the logo-menu-box
2. Fixed stretchy images in category page by adding object-fit: cover instead of background-size: cover because the images are not background images