### PR TITLE
Improved scroll on theme modal, fixed datebar styling, removed comment marks from home page

### DIFF
--- a/components/Datebar.vue
+++ b/components/Datebar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="datebar">
-    <div class="datebar-container">
+    <div class="datebar-container global-container">
       <h5 class="datebar-date">
         <span id="date-text">{{ this.date }} </span>
         <svg
@@ -66,7 +66,6 @@ export default {
 
 .datebar {
   background-color: var(--accent-color);
-  height: 4rem;
   margin: 0;
   padding: 0;
   width: 100%;
@@ -77,7 +76,7 @@ export default {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  width: 120rem;
+  padding: 0;
 }
 .datebar-date {
   margin: auto 0;
@@ -89,7 +88,6 @@ export default {
   color: var(--on-secondary);
 }
 .datebar-btns {
-  width: 8.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/components/ThemesModal.vue
+++ b/components/ThemesModal.vue
@@ -72,7 +72,6 @@ export default {
   padding: 4rem;
 
   max-height: 90vh;
-  overflow-y: auto;
 }
 .modal-container > h2,
 .modal-container > ul {
@@ -81,6 +80,8 @@ export default {
 
 .color-themes-list {
   margin: 2rem;
+  max-height: 45vh;
+  overflow-y: scroll;
 }
 
 .close-modal-button {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -57,7 +57,7 @@
             :articles="homepages.slice(7, 9)"
           />
         </section>
-        -->
+        
         <section
           class="grid-article-container six-grid-container"
           v-if="homepages[0]"
@@ -73,7 +73,7 @@
             :key="article.id"
           />
         </section>
-        -->
+        
       </div>
       <div class="mobile-view">
         <h2 class="section-title section-title-mobile">Trending Articles</h2>


### PR DESCRIPTION
1. Put overflow-y:scroll on the actual theme list rather than the container so that the "close" button is not obstructed.
2. Fixed datebar width by using global-container custom property instead of a static width.
3. Removed comment marks ("<--") from homepage 